### PR TITLE
Update README targets and upgrade sample NuGet packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A simple, lightweight implementation of an in-memory publisher/subscriber patter
 - **ASP.NET Core Ready**: Built-in support for HTTP context-aware scoping
 - **Type-Safe**: Strongly-typed message handling with generic interfaces
 - **Minimal Dependencies**: Lightweight with minimal external dependencies
-- **Multi-Target Support**: Compatible with .NET 8.0 and .NET 9.0
+- **Multi-Target Support**: Compatible with .NET 8.0, 9.0 and 10.0
 
 ## Installation
 

--- a/samples/SimpleTransitSample/SimpleTransitSample.csproj
+++ b/samples/SimpleTransitSample/SimpleTransitSample.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.7" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Clarified .NET multi-target support in README to include 8.0, 9.0, and 10.0. Upgraded Microsoft.AspNetCore.OpenApi and Swashbuckle.AspNetCore.SwaggerUI package versions in SimpleTransitSample.csproj to latest patch releases.