### PR TITLE
Update code style, workflows, and NuGet package versions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -124,6 +124,7 @@ csharp_style_prefer_null_check_over_type_check = true:suggestion
 
 # Modifier preferences
 csharp_prefer_static_local_function = true:suggestion
+csharp_prefer_static_anonymous_function = true:suggestion
 csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:silent
 
 # Code-block preferences
@@ -139,9 +140,11 @@ csharp_prefer_system_threading_lock = true:suggestion
 csharp_prefer_simple_default_expression = true:suggestion
 csharp_style_deconstructed_variable_declaration = false:suggestion
 csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_prefer_implicitly_typed_lambda_expression = true:suggestion
 csharp_style_pattern_local_over_anonymous_function = true:suggestion
 csharp_style_prefer_index_operator = true:suggestion
 csharp_style_prefer_range_operator = true:suggestion
+csharp_style_prefer_unbound_generic_type_in_nameof = true:suggestion
 csharp_style_throw_expression = true:suggestion
 csharp_style_unused_value_assignment_preference = discard_variable:none
 csharp_style_unused_value_expression_statement_preference = discard_variable:none

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,12 +22,12 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
         
     - name: Setup .NET SDK ${{ env.NET_VERSION }}
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.NET_VERSION }}
         dotnet-quality: 'ga'

--- a/.github/workflows/publish_abstractions.yml
+++ b/.github/workflows/publish_abstractions.yml
@@ -23,12 +23,12 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
         
     - name: Setup .NET SDK ${{ env.NET_VERSION }}
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.NET_VERSION }}
         dotnet-quality: 'ga'

--- a/samples/SimpleTransitSample/SimpleTransitSample.csproj
+++ b/samples/SimpleTransitSample/SimpleTransitSample.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Nerdbank.GitVersioning" Version="3.9.50"  PrivateAssets="All" />
+        <PackageReference Include="Nerdbank.GitVersioning" Version="3.10.91"  PrivateAssets="All" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updated .editorconfig with new C# code style preferences, including implicitly typed lambdas, unbound generic types in nameof, and static anonymous functions. Upgraded GitHub Actions workflows to use actions/checkout@v6 and actions/setup-dotnet@v5. Bumped Microsoft.AspNetCore.OpenApi and Swashbuckle.AspNetCore.SwaggerUI in SimpleTransitSample.csproj to newer versions. Updated Nerdbank.GitVersioning to 3.10.91 in Directory.Build.props.